### PR TITLE
Create a policy page on our content licenses.

### DIFF
--- a/policies/Changelog.html
+++ b/policies/Changelog.html
@@ -15,10 +15,16 @@
         <h1>Policy Changelog</h1>
         <p>For transparency, a list of changes to our polices are presented here.</p>
         <section>
+            <h2>June 8th 2024 - Content Licenses</h2>
+            <p>We have added our content licenses as a policy page to further clarify how we license our content made for the Resonite platform for our users and other content creators.</p>
+            <p>This includes exceptions to our standard content license, for example content made by team members for personal projects or unless otherwise specified for a piece of content.</p>
+            <p>You may review this text on <a href="https://github.com/Yellow-Dog-Man/Resonite-Website/blob/main/policies/ContentLicense.html">GitHub</a></p>
+        </section>
+        <section>
             <h2>February 14th 2024 - User Guidelines</h2>
             <p>We have made a small wording tweak to our user guidelines, in order to provide additional clarity on our adult content guidelines. The changed text is displayed below, but can also be reviewed on <a href="https://github.com/Yellow-Dog-Man/Resonite-Website/blob/main/policies/Guidelines.html">GitHub</a>.</p>
 
-            <p>Sexually explicit content <strong></strong>and activity, including kink or fetish related activity</strong> is only permitted in sessions that fit the following listed criteria:</p>
+            <p>Sexually explicit content <strong>and activity, including kink or fetish related activity</strong> is only permitted in sessions that fit the following listed criteria:</p>
         </section>
         <section>
             <h2>18th October 2023 - Terms of Service</h2>

--- a/policies/ContentLicense.html
+++ b/policies/ContentLicense.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Content Licenses</title>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/dark.css">
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <header>
+            <img src="/policies/assets/images/resonite.png"/>
+        </header>
+        <nav>
+            <a href="https://resonite.com">Home</a> | <a href="https://resonite.com/policies/index.html">Policies Page</a>
+        </nav>
+        <h1>Resonite Team Content Licenses</h1>
+        <p>Unless otherwise noted, content produced by the Resonite Team for Resonite is licensed as <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY 4.0</a>.
+        <br />You may attribute content that utilizes the Resonite Team's assets to "The Resonite Team".</p>
+        
+        <p>You may find exceptions to this either by checking for updates to this page, license metadata on common assets such as video and images, object metadata more broadly in a variety of digital assets, or other means such as for example a license text file included with a piece of content.</p>
+
+        <p>This license does not include projects produced by team members who are producing content for their own or others' purposes, e.g., personal projects, and projects that are not related to the development of the Resonite platform.</p>
+
+        <p>This license does not include content produced by other users who are not considered members of the Resonite Team, or employees of Yellow Dog Man Studios s.r.o.</p>
+    </body>
+</html>
+

--- a/policies/index.html
+++ b/policies/index.html
@@ -20,6 +20,7 @@
             <li><a href="EULA.html">EULA</a></li>
             <li><a href="Guidelines.html">User Guidelines</a></li>
             <li><a href="Security.html">Security Policy</a></li>
+            <li><a href="ContentLicense.html">Content Licenses</a></li>
             <li>Mod & Plugin Policy: Coming Soon!</li>
         </ul>
 


### PR DESCRIPTION
Also fixed a bug where we had mistakenly closed a strong tag prematurely in the changelog.