### PR TITLE
Fix mobile layout on career page.

### DIFF
--- a/css/resonite-website-a2201f.webflow.css
+++ b/css/resonite-website-a2201f.webflow.css
@@ -6085,7 +6085,7 @@ a {
 
 @media screen and (max-width: 767px) {
   #w-node-c97ba7f9-bd5c-2652-d991-8bf277ba70d4-373750a3 {
-    grid-column: span 4 / span 4;
+    grid-column: span 12;
   }
 }
 


### PR DESCRIPTION
The career page in most instances look poor on mobile. This change will display the elements at a reasonable width to the devices screen. There is an example on issue #22 of what the page looks like before this pull request.

Here is what it looks like now:
![image](https://github.com/user-attachments/assets/46480442-8a62-4a54-9c87-fdb7ce000d50)


Fixes #22 