### PR TITLE
mod-policy: Clarify stance on publicization and non-public members

### DIFF
--- a/policies/ModAndPlugin.html
+++ b/policies/ModAndPlugin.html
@@ -73,7 +73,7 @@
             <h2 id="distribution-guidance">Distribution Guidance</h2>
             <p>As covered in our <a href="https://resonite.com/policies/EULA.html">EULA</a>, redistribution of Resonite, FrooxEngine, or any of its components is not allowed. However, there are some exceptions that we've made to aid modification developers.</p>
             <h3 id="reference-assemblies">Reference Assemblies</h3>
-            <p>We allow the distribution of <a href="https://learn.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies">Reference Assemblies</a> created by modification developers.</p>
+            <p>We allow the distribution of <a href="https://learn.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies">Reference Assemblies</a> created by modification developers. These assemblies are allowed to contain non-public members or be publicized.</p>
             <p>This also includes items that can be generated from these assemblies such as:</p>
             <ul>
                 <li>IPC Bindings</li>


### PR DESCRIPTION
This PR adds one sentence to the mod policy in the "Reference Assemblies" section to clarify that mod developers are allowed to publicize them or include non-public members.

This is in accordance with the team's stance outlined in https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/5360#issuecomment-3222255749